### PR TITLE
Customui experiments

### DIFF
--- a/api/customui/api.json
+++ b/api/customui/api.json
@@ -9,14 +9,14 @@
         "description": "Additional options how the UI shall be loaded in a given location. Which properties are supported may vary depending on the location the UI is registered for.",
         "properties": {
           "height": {
-            "type": "integer",
+            "type": "string",
             "optional": "true",
-            "description": "Desired total height of the custom UI component, in pixels. The actual available height may differ (and change dynamically)."
+            "description": "Desired total height of the custom UI component. The actual available height may differ (and change dynamically)."
           },
           "width": {
-            "type": "integer",
+            "type": "string",
             "optional": "true",
-            "description": "Desired total width of the custom UI component, in pixels. The actual available height may differ (and change dynamically)."
+            "description": "Desired total width of the custom UI component. The actual available height may differ (and change dynamically)."
           },
           "hidden": {
             "type": "boolean",

--- a/api/customui/api.json
+++ b/api/customui/api.json
@@ -9,14 +9,14 @@
         "description": "Additional options how the UI shall be loaded in a given location. Which properties are supported may vary depending on the location the UI is registered for.",
         "properties": {
           "height": {
-            "type": "string",
+            "type": "integer",
             "optional": "true",
-            "description": "Desired total height of the custom UI component. The actual available height may differ (and change dynamically)."
+            "description": "Desired total height of the custom UI component, in pixels. The actual available height may differ (and change dynamically)."
           },
           "width": {
-            "type": "string",
+            "type": "integer",
             "optional": "true",
-            "description": "Desired total width of the custom UI component. The actual available height may differ (and change dynamically)."
+            "description": "Desired total width of the custom UI component, in pixels. The actual available height may differ (and change dynamically)."
           },
           "hidden": {
             "type": "boolean",

--- a/api/customui/parent.js
+++ b/api/customui/parent.js
@@ -261,10 +261,10 @@ var ex_customui = class extends ExtensionCommon.ExtensionAPI {
     }
 
     const setWebextFrameDynamicDimension = function(frame, options, dimensionName, defaultValue) {
-      frame[dimensionName] = options[dimensionName] || defaultValue;
+      frame[dimensionName] = (options[dimensionName] || defaultValue) + "px";
       frame.addCustomUILocalOptionsListener(lOptions => {
         if (typeof lOptions[dimensionName] === "string") {
-          frame[dimensionName] = lOptions[dimensionName];
+          frame[dimensionName] = lOptions[dimensionName] + "px";
           frame.style[dimensionName] = frame[dimensionName];
         }
         if (typeof lOptions.hidden === "boolean") {

--- a/api/customui/parent.js
+++ b/api/customui/parent.js
@@ -263,7 +263,7 @@ var ex_customui = class extends ExtensionCommon.ExtensionAPI {
     const setWebextFrameDynamicDimension = function(frame, options, dimensionName, defaultValue) {
       frame[dimensionName] = (options[dimensionName] || defaultValue) + "px";
       frame.addCustomUILocalOptionsListener(lOptions => {
-        if (typeof lOptions[dimensionName] === "string") {
+        if (typeof lOptions[dimensionName] === "number") {
           frame[dimensionName] = lOptions[dimensionName] + "px";
           frame.style[dimensionName] = frame[dimensionName];
         }

--- a/background.js
+++ b/background.js
@@ -8,7 +8,7 @@ let messenger = browser; // to prevent errors in linting...
     // default parameter only used at first startup
     function toggleTidybird(settings) {
       let isShowing = settings.isShowing ?? true;
-      let width = settings.width ?? 244;
+      let width = settings.width;
       if (
         // startupEvent can also be an event
         (startupEvent === true && isShowing) ||

--- a/background.js
+++ b/background.js
@@ -7,6 +7,7 @@ let messenger = browser; // to prevent errors in linting...
 
     // default parameter only used at first startup
     function toggleTidybird(settings) {
+      // if a setting is not set, it will be 'undefined'
       let isShowing = settings.isShowing ?? true;
       let width = settings.width;
       if (
@@ -29,16 +30,12 @@ let messenger = browser; // to prevent errors in linting...
       }
     }
 
-    function onGet(settings) {
-      toggleTidybird(settings); // if not set => undefined => default parameter value
-    }
-
     function onError(error) {
-      console.log(`Error in tidybird getting settings: ${error}`);
+      console.error(`Error in tidybird getting settings: ${error}`);
     }
 
     let gettingSetting = messenger.storage.local.get(["isShowing", "width"]);
-    gettingSetting.then(onGet, onError);
+    gettingSetting.then(toggleTidybird, onError);
   }
 
   // initial startup (or not)

--- a/background.js
+++ b/background.js
@@ -4,10 +4,11 @@ let messenger = browser; // to prevent errors in linting...
   // the first parameter of this function gets tab information when using the button
   function toggleTidybirdBySettings(startupEvent = false) {
     let htmlPage = "content/tidybirdpane.html";
-    let isShowingSetting = "isShowing";
 
     // default parameter only used at first startup
-    function toggleTidybird(isShowing = true) {
+    function toggleTidybird(settings) {
+      let isShowing = settings.isShowing ?? true;
+      let width = settings.width ?? 244;
       if (
         // startupEvent can also be an event
         (startupEvent === true && isShowing) ||
@@ -16,29 +17,27 @@ let messenger = browser; // to prevent errors in linting...
         messenger.ex_customui.add(
           messenger.ex_customui.LOCATION_MESSAGING,
           htmlPage,
-          { width: 200 } // TODO: take width from last time (setting has no use)
+          { width } // this is an "object shorthand" = { "width": width }
         );
-        messenger.storage.local.set({ [isShowingSetting]: true });
+        messenger.storage.local.set({ ["isShowing"]: true });
       } else {
+        messenger.storage.local.set({ ["isShowing"]: false });
         messenger.ex_customui.remove(
           messenger.ex_customui.LOCATION_MESSAGING,
           htmlPage
         );
-        messenger.storage.local.set({ [isShowingSetting]: false });
       }
     }
 
     function onGet(settings) {
-      toggleTidybird(settings[isShowingSetting]); // if not set => undefined => default parameter value
+      toggleTidybird(settings); // if not set => undefined => default parameter value
     }
 
     function onError(error) {
-      console.log(
-        `Error in tidybird getting setting ${isShowingSetting}: ${error}`
-      );
+      console.log(`Error in tidybird getting settings: ${error}`);
     }
 
-    let gettingSetting = messenger.storage.local.get(isShowingSetting);
+    let gettingSetting = messenger.storage.local.get(["isShowing", "width"]);
     gettingSetting.then(onGet, onError);
   }
 

--- a/background.js
+++ b/background.js
@@ -12,7 +12,7 @@ let messenger = browser; // to prevent errors in linting...
         messenger.ex_customui.add(
           messenger.ex_customui.LOCATION_MESSAGING,
           htmlPage,
-          { width: "200%" } // TODO: take width from last time (setting has no use, maybe: relative/absolute)
+          { width: "200" } // TODO: take width from last time (setting has no use)
         );
         messenger.storage.local.set({ [isShowingSetting]: true });
       } else {

--- a/background.js
+++ b/background.js
@@ -12,7 +12,7 @@ let messenger = browser; // to prevent errors in linting...
         messenger.ex_customui.add(
           messenger.ex_customui.LOCATION_MESSAGING,
           htmlPage,
-          { width: "200" } // TODO: take width from last time (setting has no use)
+          { width: 200 } // TODO: take width from last time (setting has no use)
         );
         messenger.storage.local.set({ [isShowingSetting]: true });
       } else {

--- a/background.js
+++ b/background.js
@@ -1,5 +1,4 @@
-// messenger is not yet known in TB 68
-let messenger = browser;
+let messenger = browser; // to prevent errors in linting...
 
 (async () => {
   // the first parameter of this function gets tab information when using the button
@@ -13,6 +12,7 @@ let messenger = browser;
         messenger.ex_customui.add(
           messenger.ex_customui.LOCATION_SIDEBAR,
           htmlPage
+          //{ width: "200%" } // TODO: take width from last time (setting has no use, maybe: relative/absolute)
         );
         messenger.storage.local.set({ [isShowingSetting]: true });
       } else {

--- a/content/tidybirdpane_script.js
+++ b/content/tidybirdpane_script.js
@@ -182,3 +182,5 @@ async function gotMRMFolders(mostRecentlyModifiedFolders) {
 // do with events, as direct return raises an exception
 browser.tidybird_api.getMRMFolders.addListener(gotMRMFolders, 30);
 //TODO: idea: keep our own list of MRM folders, so we can include or exclude any folder. Before of subfolders of removed/renamed folders (with MRM they are no longer in the list)
+
+//browser.ex_customui.setLocalOptions({ width: "1000px" });

--- a/content/tidybirdpane_script.js
+++ b/content/tidybirdpane_script.js
@@ -113,6 +113,22 @@ async function themeChangedListener(themeUpdateInfo) {
 messenger.theme.onUpdated.addListener(themeChangedListener);
 applyThemeColors();
 
+/**
+ * Keep track of the width
+ *  must be run in this context: access to window
+ **/
+async function windowRemovedListener(anEvent) {
+  let innerWidth = window.innerWidth;
+  if (innerWidth != 0) {
+    // as the context is removed in TB78, the width is 0
+    //  we don't save this so we don't reset the saved with (from shutdown) when button is clicked
+    browser.storage.local.set({ width: innerWidth });
+  }
+}
+// onbeforeunload does not work (at least not in TB78)
+// onunload is executed after the context is remove in TB78 when button is clicked
+window.addEventListener("unload", windowRemovedListener);
+
 /*
  * The move functionality
  */
@@ -325,5 +341,4 @@ async function gotMRMFolders(mostRecentlyModifiedFolders) {
 browser.tidybird_api.getMRMFolders.addListener(gotMRMFolders, 30);
 //TODO: idea: keep our own list of MRM folders, so we can include or exclude any folder. Before of subfolders of removed/renamed folders (with MRM they are no longer in the list)
 
-//browser.ex_customui.setLocalOptions({ width: "1000px" });
 /* vi: set tabstop=2 shiftwidth=2 softtabstop=2 expandtab: */


### PR DESCRIPTION
This PR makes tidybird to record it's width on close and re-apply when shown again. Which means it should fix #15.
It uses (and prepared) a new functionality of customui (see rsjtdrjgfuzkfg/thunderbird-experiments/pull/9), so the recorded width can be applied.
There is a bug in Thunderbird 78, which makes tidybird only to record it's width on window close, not when the button is clicked. This will probably be addressed in the tb78 branch.